### PR TITLE
Fix ProcessManager, align better with dart:io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,20 @@
-## 0.2.1
+## 0.3.0
+
+- **BREAKING CHANGE**: The `arguments` argument to `ProcessManager.spawn` is
+  now positional (not named) and required. This makes it more similar to the
+  built-in `Process.start`, and easier to use as a drop in replacement:
+
+```dart
+processManager.spawn('dart', ['--version']);
+```
 
 - Fixed a bug where processes created from `ProcessManager.spawn` could not
   have their `stdout`/`stderr` read through their respective getters (a runtime
   error was always thrown).
 
-- Added `ProcessMangaer.background`, which does not forward `stdin`.
+- Added `ProcessMangaer#spawnBackground`, which does not forward `stdin`.
 
-- Added `ProcessManager.headless`, which does not forward any standard I/O.
+- Added `ProcessManager#spawnDetached`, which does not forward any I/O.
 
 ## 0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
-## 0.1.0
+## 0.2.1
+
+- Fixed a bug where processes created from `ProcessManager.spawn` could not
+  have their `stdout`/`stderr` read through their respective getters (a runtime
+  error was always thrown).
+
+- Added `ProcessMangaer.background`, which does not forward `stdin`.
+
+- Added `ProcessManager.headless`, which does not forward any standard I/O.
+
+## 0.2.0
 
 - Initial commit of...
    - `FutureOr<bool> String isExecutable(path)`.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@ Contains utilities for the Dart VM's `dart:io`.
 
 [![Build Status](https://travis-ci.org/dart-lang/io.svg?branch=master)](https://travis-ci.org/dart-lang/io)
 
+## Contributing
+
+> **NOTE**: Due to the changing nature of the Dart SDK (towards 2.0.0), running
+> `dartfmt` requires the local executable:
+
+```sh
+$ pub run dart_style:format
+```
+
 ## Usage - `io.dart`
 
 ### Files

--- a/example/spawn_process.dart
+++ b/example/spawn_process.dart
@@ -12,19 +12,19 @@ Future<Null> main() async {
 
   // Runs dartfmt --version and outputs the result via stdout.
   print('Running dartfmt --version');
-  var spawn = await manager.spawn('dartfmt', arguments: ['--version']);
+  var spawn = await manager.spawn('dartfmt', ['--version']);
   await spawn.exitCode;
 
   // Runs dartfmt -n . and outputs the result via stdout.
   print('Running dartfmt -n .');
-  spawn = await manager.spawn('dartfmt', arguments: ['-n', '.']);
+  spawn = await manager.spawn('dartfmt', ['-n', '.']);
   await spawn.exitCode;
 
   // Runs pub publish. Upon hitting a blocking stdin state, you may directly
   // output to the processes's stdin via your own, similar to how a bash or
   // shell script would spawn a process.
   print('Running pub publish');
-  spawn = await manager.spawn('pub', arguments: ['publish']);
+  spawn = await manager.spawn('pub', ['publish']);
   await spawn.exitCode;
 
   // Closes stdin for the entire program.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,5 +12,6 @@ dependencies:
   meta: ^1.0.2
 
 dev_dependencies:
+  dart_style: ^1.0.7
   path: ^1.0.0
   test: ^0.12.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: io
 description: >
   Utilities for the Dart VM Runtime.
-version: 0.2.0
+version: 0.2.1
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/io
 

--- a/test/process_manager_test.dart
+++ b/test/process_manager_test.dart
@@ -42,7 +42,7 @@ void main() {
     test('should output Hello from another process [via stdout]', () async {
       final spawn = await processManager.spawn(
         'dart',
-        arguments: [p.join('test', '_files', 'stdout_hello.dart')],
+        [p.join('test', '_files', 'stdout_hello.dart')],
       );
       await spawn.exitCode;
       expect(stdoutLog, ['Hello']);
@@ -51,7 +51,7 @@ void main() {
     test('should output Hello from another process [via stderr]', () async {
       final spawn = await processManager.spawn(
         'dart',
-        arguments: [p.join('test', '_files', 'stderr_hello.dart')],
+        [p.join('test', '_files', 'stderr_hello.dart')],
       );
       await spawn.exitCode;
       expect(stderrLog, ['Hello']);
@@ -60,7 +60,7 @@ void main() {
     test('should forward stdin to another process', () async {
       final spawn = await processManager.spawn(
         'dart',
-        arguments: [p.join('test', '_files', 'stdin_echo.dart')],
+        [p.join('test', '_files', 'stdin_echo.dart')],
       );
       spawn.stdin.writeln('Ping');
       await spawn.exitCode;
@@ -71,7 +71,7 @@ void main() {
       test('.stdout is readable', () async {
         final spawn = await processManager.spawn(
           'dart',
-          arguments: [p.join('test', '_files', 'stdout_hello.dart')],
+          [p.join('test', '_files', 'stdout_hello.dart')],
         );
         expect(await spawn.stdout.transform(UTF8.decoder).first, 'Hello');
       });
@@ -79,7 +79,7 @@ void main() {
       test('.stderr is readable', () async {
         final spawn = await processManager.spawn(
           'dart',
-          arguments: [p.join('test', '_files', 'stderr_hello.dart')],
+          [p.join('test', '_files', 'stderr_hello.dart')],
         );
         expect(await spawn.stderr.transform(UTF8.decoder).first, 'Hello');
       });

--- a/test/process_manager_test.dart
+++ b/test/process_manager_test.dart
@@ -64,9 +64,25 @@ void main() {
       );
       spawn.stdin.writeln('Ping');
       await spawn.exitCode;
-      // TODO: https://github.com/dart-lang/sdk/issues/30119.
-      // expect(stdoutLog, ['You said: Ping', '\n']);
       expect(stdoutLog.join(''), contains('You said: Ping'));
+    });
+
+    group('should return a Process where', () {
+      test('.stdout is readable', () async {
+        final spawn = await processManager.spawn(
+          'dart',
+          arguments: [p.join('test', '_files', 'stdout_hello.dart')],
+        );
+        expect(await spawn.stdout.transform(UTF8.decoder).first, 'Hello');
+      });
+
+      test('.stderr is readable', () async {
+        final spawn = await processManager.spawn(
+          'dart',
+          arguments: [p.join('test', '_files', 'stderr_hello.dart')],
+        );
+        expect(await spawn.stderr.transform(UTF8.decoder).first, 'Hello');
+      });
     });
   });
 }


### PR DESCRIPTION
Closes #18.

Added a breaking change to align `spawn` with `Process.start`, but we don't have many uses yet.

Also changed to use a local dependency for `dartfmt` to make it easier for folks both with the stable and dev SDK to be able to format the code prior to sending it off to travis.