### PR TITLE
Make the forScript code paths ignore the ansiOutputEnabled property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.3.2+1
+
+* `ansi.dart`
+
+  * The "forScript" code paths now ignore the `ansiOutputEnabled` value. Affects
+    the `escapeForScript` property on `AnsiCode` and the `wrap` and `wrapWith`
+    functions when `forScript` is true.
+
 ## 0.3.2
 
 * `ansi.dart`

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: io
 description: >
   Utilities for the Dart VM Runtime.
-version: 0.3.2
+version: 0.3.2+1
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/io
 

--- a/test/ansi_code_test.dart
+++ b/test/ansi_code_test.dart
@@ -9,6 +9,7 @@ import 'package:test/test.dart';
 
 const _ansiEscapeLiteral = '\x1B';
 const _ansiEscapeForScript = '\\033';
+const sampleInput = 'sample input';
 
 void main() {
   group('ansiOutputEnabled', () {
@@ -27,6 +28,19 @@ void main() {
       overrideAnsiOutput(false, () {
         expect(ansiOutputEnabled, isFalse);
       });
+    });
+
+    test('forScript variaents ignore `ansiOutputEnabled`', () {
+      final expected =
+          '$_ansiEscapeForScript[34m$sampleInput$_ansiEscapeForScript[0m';
+
+      for (var override in [true, false]) {
+        overrideAnsiOutput(override, () {
+          expect(blue.escapeForScript, '$_ansiEscapeForScript[34m');
+          expect(blue.wrap(sampleInput, forScript: true), expected);
+          expect(wrapWith(sampleInput, [blue], forScript: true), expected);
+        });
+      }
     });
   });
 
@@ -64,10 +78,8 @@ void main() {
     }
   });
 
-  final sampleInput = 'sample input';
-
   for (var forScript in [true, false]) {
-    group(forScript ? 'for script' : 'literal', () {
+    group(forScript ? 'forScript' : 'escaped', () {
       final escapeLiteral =
           forScript ? _ansiEscapeForScript : _ansiEscapeLiteral;
 


### PR DESCRIPTION
Assume these are being used for generating scripts and not runtime
behavior