### PR TITLE
Remove unneeded dart:async imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: dart
 
 dart:
-  - 2.0.0
+  - 2.1.0
   - dev
 
 dart_task:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.5-dev
+
+* Require Dart >=2.1
+
 ## 0.3.4
 
 * Fix a number of issues affecting the package score on `pub.dev`.

--- a/lib/src/copy_path.dart
+++ b/lib/src/copy_path.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:io';
 
 import 'package:path/path.dart' as p;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,11 +2,11 @@ name: io
 description: >-
   Utilities for the Dart VM Runtime including support for ANSI colors,
   file copying, and standard exit code values.
-version: 0.3.4
+version: 0.3.5-dev
 homepage: https://github.com/dart-lang/io
 
 environment:
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: ">=2.1.0 <3.0.0"
 
 dependencies:
   charcode: ^1.0.0

--- a/test/copy_path_test.dart
+++ b/test/copy_path_test.dart
@@ -3,8 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('vm')
-import 'dart:async';
-
 import 'package:io/io.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';


### PR DESCRIPTION
Since Dart 2.1, Future and Stream have been exported from dart:core

Alternatively, if for some reason this package must continue to support
Dart 2.0, we can make an exception for these internally.