### PR TITLE
Migrate to null safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0
+
+- Migrate this package to null-safety
+
 ## 0.3.6-dev
 
 * Require Dart >=2.12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,6 @@
 ## 0.4.0
 
-- Migrate this package to null-safety
-
-## 0.3.6-dev
-
+* Migrate this package to null-safety
 * Require Dart >=2.12
 
 ## 0.3.5

--- a/lib/src/ansi_code.dart
+++ b/lib/src/ansi_code.dart
@@ -81,9 +81,8 @@ class AnsiCode {
   /// Represents the value as an unescaped literal suitable for scripts.
   String get escapeForScript => '$_ansiEscapeForScript[${code}m';
 
-  String _escapeValue({bool forScript = false}) {
-    return forScript ? escapeForScript : escape;
-  }
+  String _escapeValue({bool forScript = false}) =>
+      forScript ? escapeForScript : escape;
 
   /// Wraps [value] with the [escape] value for this code, followed by
   /// [resetAll].

--- a/lib/src/ansi_code.dart
+++ b/lib/src/ansi_code.dart
@@ -18,11 +18,11 @@ const _ansiEscapeForScript = '\\033';
 ///
 /// [overrideAnsiOutput] is provided to make this easy.
 bool get ansiOutputEnabled =>
-    Zone.current[AnsiCode] as bool ??
+    Zone.current[AnsiCode] as bool? ??
     (io.stdout.supportsAnsiEscapes && io.stderr.supportsAnsiEscapes);
 
 /// Returns `true` no formatting is required for [input].
-bool _isNoop(bool skip, String input, bool forScript) =>
+bool _isNoop(bool skip, String? input, bool? forScript) =>
     skip ||
     input == null ||
     input.isEmpty ||
@@ -65,7 +65,7 @@ class AnsiCode {
   /// The [AnsiCode] that resets this value, if one exists.
   ///
   /// Otherwise, `null`.
-  final AnsiCode reset;
+  final AnsiCode? reset;
 
   /// A description of this code.
   final String name;
@@ -82,7 +82,6 @@ class AnsiCode {
   String get escapeForScript => '$_ansiEscapeForScript[${code}m';
 
   String _escapeValue({bool forScript = false}) {
-    forScript ??= false;
     return forScript ? escapeForScript : escape;
   }
 
@@ -96,11 +95,11 @@ class AnsiCode {
   ///   * [value] is `null` or empty
   ///   * both [ansiOutputEnabled] and [forScript] are `false`.
   ///   * [type] is [AnsiCodeType.reset]
-  String wrap(String value, {bool forScript = false}) =>
+  String? wrap(String? value, {bool forScript = false}) =>
       _isNoop(type == AnsiCodeType.reset, value, forScript)
           ? value
           : '${_escapeValue(forScript: forScript)}$value'
-              '${reset._escapeValue(forScript: forScript)}';
+              '${reset!._escapeValue(forScript: forScript)}';
 
   @override
   String toString() => '$name ${type._name} ($code)';
@@ -120,9 +119,8 @@ class AnsiCode {
 ///   * [codes] contains more than one value of type [AnsiCodeType.foreground].
 ///   * [codes] contains more than one value of type [AnsiCodeType.background].
 ///   * [codes] contains any value of type [AnsiCodeType.reset].
-String wrapWith(String value, Iterable<AnsiCode> codes,
+String? wrapWith(String? value, Iterable<AnsiCode> codes,
     {bool forScript = false}) {
-  forScript ??= false;
   // Eliminate duplicates
   final myCodes = codes.toSet();
 
@@ -150,7 +148,6 @@ String wrapWith(String value, Iterable<AnsiCode> codes,
       case AnsiCodeType.reset:
         throw ArgumentError.value(
             codes, 'codes', 'Cannot contain reset codes.');
-        break;
     }
   }
 

--- a/lib/src/permissions.dart
+++ b/lib/src/permissions.dart
@@ -56,7 +56,7 @@ int _permissionBitIndex(_FilePermission permission, _FilePermissionRole role) {
 /// **NOTE**: On windows this always returns `true`.
 FutureOr<bool> isExecutable(
   String path, {
-  bool isWindows,
+  bool? isWindows,
   FutureOr<FileStat> Function(String path) getStat = FileStat.stat,
 }) {
   // Windows has no concept of executable.
@@ -65,7 +65,7 @@ FutureOr<bool> isExecutable(
   if (stat is FileStat) {
     return _isExecutable(stat);
   }
-  return (stat as Future<FileStat>).then(_isExecutable);
+  return stat.then(_isExecutable);
 }
 
 bool _isExecutable(FileStat stat) =>

--- a/lib/src/process_manager.dart
+++ b/lib/src/process_manager.dart
@@ -38,10 +38,10 @@ abstract class ProcessManager {
   /// May manually specify whether the current platform [isWindows], otherwise
   /// this is derived from the Dart runtime (i.e. [io.Platform.isWindows]).
   factory ProcessManager({
-    Stream<List<int>> stdin,
-    io.IOSink stdout,
-    io.IOSink stderr,
-    bool isWindows,
+    Stream<List<int>>? stdin,
+    io.IOSink? stdout,
+    io.IOSink? stderr,
+    bool? isWindows,
   }) {
     stdin ??= sharedStdIn;
     stdout ??= io.stdout;
@@ -69,8 +69,8 @@ abstract class ProcessManager {
   Future<io.Process> spawn(
     String executable,
     Iterable<String> arguments, {
-    String workingDirectory,
-    Map<String, String> environment,
+    String? workingDirectory,
+    Map<String, String>? environment,
     bool includeParentEnvironment = true,
     bool runInShell = false,
     io.ProcessStartMode mode = io.ProcessStartMode.normal,
@@ -97,8 +97,8 @@ abstract class ProcessManager {
   Future<io.Process> spawnBackground(
     String executable,
     Iterable<String> arguments, {
-    String workingDirectory,
-    Map<String, String> environment,
+    String? workingDirectory,
+    Map<String, String>? environment,
     bool includeParentEnvironment = true,
     bool runInShell = false,
     io.ProcessStartMode mode = io.ProcessStartMode.normal,
@@ -128,8 +128,8 @@ abstract class ProcessManager {
   Future<io.Process> spawnDetached(
     String executable,
     Iterable<String> arguments, {
-    String workingDirectory,
-    Map<String, String> environment,
+    String? workingDirectory,
+    Map<String, String>? environment,
     bool includeParentEnvironment = true,
     bool runInShell = false,
     io.ProcessStartMode mode = io.ProcessStartMode.normal,

--- a/lib/src/shared_stdin.dart
+++ b/lib/src/shared_stdin.dart
@@ -26,10 +26,10 @@ final SharedStdIn sharedStdIn = SharedStdIn(stdin);
 /// used directly.
 @visibleForTesting
 class SharedStdIn extends Stream<List<int>> {
-  StreamController<List<int>> _current;
-  StreamSubscription<List<int>> _sub;
+  StreamController<List<int>>? _current;
+  StreamSubscription<List<int>>? _sub;
 
-  SharedStdIn([Stream<List<int>> stream]) {
+  SharedStdIn([Stream<List<int>>? stream]) {
     _sub = (stream ??= stdin).listen(_onInput);
   }
 
@@ -64,10 +64,10 @@ class SharedStdIn extends Stream<List<int>> {
 
   @override
   StreamSubscription<List<int>> listen(
-    void Function(List<int> event) onData, {
-    Function onError,
-    void Function() onDone,
-    bool cancelOnError,
+    void Function(List<int> event)? onData, {
+    Function? onError,
+    void Function()? onDone,
+    bool? cancelOnError,
   }) {
     if (_sub == null) {
       throw StateError('Stdin has already been terminated.');
@@ -92,7 +92,7 @@ class SharedStdIn extends Stream<List<int>> {
     if (_sub == null) {
       throw StateError('Stdin has already been terminated.');
     }
-    await _sub.cancel();
+    await _sub?.cancel();
     await _current?.close();
     _sub = null;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,19 +2,24 @@ name: io
 description: >-
   Utilities for the Dart VM Runtime including support for ANSI colors,
   file copying, and standard exit code values.
-version: 0.3.6-dev
+version: 0.4.0-dev
 repository: https://github.com/dart-lang/io
 
 environment:
-  sdk: ">=2.11.99 <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
 
 dependencies:
-  meta: ^1.0.2
-  path: ^1.5.1
-  string_scanner: ">=0.1.5 <2.0.0"
+  meta: ^1.3.0
+  path: ^1.8.0
+  string_scanner: ^1.1.0
 
 dev_dependencies:
   dart_style: ^1.0.7
-  pedantic: ^1.2.0
-  test: ^1.0.0
-  test_descriptor: ^2.0.0
+  pedantic: ^1.10.0
+  test: ^1.16.0
+  test_descriptor: ^2.0.0-nullsafety
+
+dependency_overrides:
+  # Necessary until the test package supports 0.4.0
+  test: ^1.16.0
+  test_core: ^0.3.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dev_dependencies:
   dart_style: ^1.0.7
   pedantic: ^1.10.0
   test: ^1.16.0
-  test_descriptor: ^2.0.0-nullsafety
+  test_descriptor: ^2.0.0
 
 dependency_overrides:
   # Necessary until the test package supports 0.4.0

--- a/test/ansi_code_test.dart
+++ b/test/ansi_code_test.dart
@@ -72,9 +72,9 @@ void main() {
       if (style == styleBold) {
         expect(style.reset, resetBold);
       } else {
-        expect(style.reset.code, equals(style.code + 20));
+        expect(style.reset!.code, equals(style.code + 20));
       }
-      expect(style.name, equals(style.reset.name));
+      expect(style.name, equals(style.reset!.name));
     }
   });
 
@@ -169,7 +169,7 @@ void main() {
               '');
         });
 
-        _test(null, () {
+        _test('null', () {
           expect(
               wrapWith(null, [blue, backgroundWhite, styleBold],
                   forScript: forScript),

--- a/test/process_manager_test.dart
+++ b/test/process_manager_test.dart
@@ -76,7 +76,7 @@ void main() {
       );
       spawn.stdin.writeln('Ping');
       await spawn.exitCode;
-      expect(stdoutLog.join(''), contains('You said: Ping'));
+      expect(stdoutLog.join(), contains('You said: Ping'));
     });
 
     group('should return a Process where', () {

--- a/test/process_manager_test.dart
+++ b/test/process_manager_test.dart
@@ -14,10 +14,10 @@ import 'package:test/test.dart';
 
 void main() {
   StreamController<String> fakeStdIn;
-  ProcessManager processManager;
+  late ProcessManager processManager;
   SharedStdIn sharedStdIn;
-  List<String> stdoutLog;
-  List<String> stderrLog;
+  late List<String> stdoutLog;
+  late List<String> stderrLog;
 
   test('spawn functions should match the type definition of Process.start', () {
     const isStartProcess = TypeMatcher<StartProcess>();
@@ -49,9 +49,11 @@ void main() {
       );
     });
 
+    final dart = Platform.executable;
+
     test('should output Hello from another process [via stdout]', () async {
       final spawn = await processManager.spawn(
-        'dart',
+        dart,
         [p.join('test', '_files', 'stdout_hello.dart')],
       );
       await spawn.exitCode;
@@ -60,7 +62,7 @@ void main() {
 
     test('should output Hello from another process [via stderr]', () async {
       final spawn = await processManager.spawn(
-        'dart',
+        dart,
         [p.join('test', '_files', 'stderr_hello.dart')],
       );
       await spawn.exitCode;
@@ -69,7 +71,7 @@ void main() {
 
     test('should forward stdin to another process', () async {
       final spawn = await processManager.spawn(
-        'dart',
+        dart,
         [p.join('test', '_files', 'stdin_echo.dart')],
       );
       spawn.stdin.writeln('Ping');
@@ -80,7 +82,7 @@ void main() {
     group('should return a Process where', () {
       test('.stdout is readable', () async {
         final spawn = await processManager.spawn(
-          'dart',
+          dart,
           [p.join('test', '_files', 'stdout_hello.dart')],
         );
         expect(await spawn.stdout.transform(utf8.decoder).first, 'Hello');
@@ -88,7 +90,7 @@ void main() {
 
       test('.stderr is readable', () async {
         final spawn = await processManager.spawn(
-          'dart',
+          dart,
           [p.join('test', '_files', 'stderr_hello.dart')],
         );
         expect(await spawn.stderr.transform(utf8.decoder).first, 'Hello');

--- a/test/shared_stdin_test.dart
+++ b/test/shared_stdin_test.dart
@@ -10,10 +10,10 @@ import 'package:test/test.dart';
 
 void main() {
   // ignore: close_sinks
-  StreamController<String> fakeStdIn;
-  SharedStdIn sharedStdIn;
+  late StreamController<String> fakeStdIn;
+  late SharedStdIn sharedStdIn;
 
-  setUp(() async {
+  setUp(() {
     fakeStdIn = StreamController<String>(sync: true);
     sharedStdIn = SharedStdIn(fakeStdIn.stream.map((s) => s.codeUnits));
   });


### PR DESCRIPTION
The `wrap` api is kind of awkward to use with null-safety, it might be easier to just disallow `null` inputs? I kept compatibility to existing apis.

Closes #63.